### PR TITLE
update warning about WMO and -warn-long-* flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ You’ll end up with `slowest.log` file containing list of all files in the proj
 2.4605 (  0.3%)  {compile: SlideInPresentationAnimator.o <= SlideInPresentationAnimator.swift }
 ```
 
-⚠️ Warning: This technique doesn’t work for targets using Whole Module Optimization. Please temporarily disable WMO if you have it enabled.
-
 📖 Sources:
 
 - [Diving into Swift compiler performance](https://koke.me/2017/03/24/diving-into-swift-compiler-performance/)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Build again and you should now see warnings like these:
 
 Next step is to address code that Swift compiler has problems with. [John Sundell](https://www.swiftbysundell.com/posts/improving-swift-compile-times) and [Robert Gummesson](https://medium.com/@RobertGummesson/regarding-swift-build-time-optimizations-fc92cdd91e31) are here to help you with that.
 
-⚠️ Warning: This technique doesn’t work for targets using Whole Module Optimization. Please temporarily disable WMO if you have it enabled.
+⚠️ Warning: Prior to Xcode 9.1, this technique doesn’t work for targets using Whole Module Optimization. Please temporarily disable WMO if you have it enabled.
 
 📖 Sources:
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ Build again and you should now see warnings like these:
 
 Next step is to address code that Swift compiler has problems with. [John Sundell](https://www.swiftbysundell.com/posts/improving-swift-compile-times) and [Robert Gummesson](https://medium.com/@RobertGummesson/regarding-swift-build-time-optimizations-fc92cdd91e31) are here to help you with that.
 
-⚠️ Warning: Prior to Xcode 9.1, this technique doesn’t work for targets using Whole Module Optimization. Please temporarily disable WMO if you have it enabled.
-
 📖 Sources:
 
 - [Guarding Against Long Compiles](http://khanlou.com/2016/12/guarding-against-long-compiles/)


### PR DESCRIPTION
In Xcode 9.1 (9B55), I have WMO enabled and both of the `-warn-long-*` flags in my Swift flags. I am seeing warnings for both slow expressions and slow functions.

Is it possible that something was fixed between Xcode 9.0 and 9.1? Or maybe I'm misunderstanding what was meant by "doesn't work"?

![image](https://user-images.githubusercontent.com/238331/33528714-dea01d4c-d819-11e7-8391-47bc2d9b236f.png)
