### PR TITLE
Adding post_install to new xcode build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,23 @@ post_install do |installer|
 end
 ```
 
+If you use new Xcode build system and show the alert "Target Pods cannot link framework Foundation.framework", prefere use this `post_install`
+
+```ruby
+post_install do |installer|
+  podsTargets = installer.pods_project.targets.find_all { |target| target.name.start_with?('Pods') }
+  podsTargets.each do |target|
+    target.frameworks_build_phase.clear
+    target.build_configurations.each do |config|
+      if config.name == 'Debug'
+        config.build_settings['OTHER_SWIFT_FLAGS'] = ['$(inherited)', '-Onone']
+        config.build_settings['SWIFT_OPTIMIZATION_LEVEL'] = '-Owholemodule'
+      end
+    end
+  end
+end
+```
+
 and then run `$ pod install`. Make sure to compare build times before and after this change to confirm there's an improvement.
 
 # Third-party dependencies


### PR DESCRIPTION
When using the new build sytem, appears a warning "Target Pods cannot link framework Foundation.framework". Using this post_install will fix this problem. 

You can find this issue in https://github.com/CocoaPods/CocoaPods/issues/7251 . But even after the CocoaPods 1.5.3 keep appearing this alert.