### PR TITLE
Add info about Rome

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ There are two ways you can embed third-party dependencies in your projects:
 
 CocoaPods being the most popular [dependency manager](https://twitter.com/arekholko/status/923989580948402177) for iOS by design leads to longer compile times, as the source code of 3rd-party libraries in most cases gets compiled each time you perform a clean build. In general you shouldn’t have to do that often but in reality, you do (e.g. because of switching branches, Xcode bugs, etc.).
 
-Carthage, even though it’s harder to use, is a better choice if you care about build times. You build external dependencies only when you change something in the dependency list (add a new framework, update a framework to a newer version, etc.). That may take 5 or 15 minutes to complete but you do it a lot less often than building code embedded with CocoaPods.
+Carthage, even though it’s harder to use, is a better choice if you care about build times. You build external dependencies only when you change something in the dependency list (add a new framework, update a framework to a newer version, etc.). That may take 5 or 15 minutes to complete but you do it a lot less often than building code embedded with CocoaPods. You can even skip those initial minutes using [Rome](https://github.com/blender/Rome).
 
 📖 Sources:
 


### PR DESCRIPTION
When using Carthage, it is possible to skip:
- the initial build time 
- build times when switching dependency versions
- build time when switching branches 
 
by using [Rome](https://github.com/blender/Rome) 